### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-01-09
+
 ### Changed
 
 - **MediaConvert エンコード設定の最適化**


### PR DESCRIPTION
## Release v0.2.0

CHANGELOG.md の `[Unreleased]` を `[0.2.0] - 2026-01-09` に更新