### PR TITLE
feat(cli): add parallel iCloud download and S3 upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **並列転送機能**
+  - `vco convert --parallel N` オプションで同時転送数を設定（デフォルト: 3、範囲: 1-10）
+  - iCloud ダウンロードと S3 アップロードを並列実行
+  - Rich Progress による全体進捗表示（"Downloading 3/10 files"）
+  - Ctrl+C による転送のグレースフルキャンセル
+  - 一部失敗時も残りの転送を継続
+
 ## [0.2.0] - 2026-01-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -133,11 +133,16 @@ vco convert --skip-icloud
 # Set download timeout for iCloud videos (default: 300 seconds, range: 30-3600)
 vco convert --download-timeout 600
 
+# Set parallel transfer concurrency (default: 3, range: 1-10)
+vco convert --parallel 5
+
 # Skip confirmation prompts
 vco convert --yes
 ```
 
 **Automatic iCloud Download**: When running `vco convert`, iCloud-only videos are automatically downloaded using Swift PhotoKit. Use `--skip-icloud` to skip them.
+
+**Parallel Transfers**: Downloads and uploads run in parallel (default: 3 concurrent). Use `--parallel N` to adjust. Press Ctrl+C to cancel gracefully.
 
 Conversions are processed asynchronously via AWS Step Functions. After submitting a conversion, you can check status and manage tasks:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -133,11 +133,16 @@ vco convert --skip-icloud
 # iCloud ダウンロードのタイムアウトを設定（デフォルト: 300 秒、範囲: 30-3600）
 vco convert --download-timeout 600
 
+# 並列転送の同時実行数を設定（デフォルト: 3、範囲: 1-10）
+vco convert --parallel 5
+
 # 確認プロンプトをスキップ
 vco convert --yes
 ```
 
 **iCloud 動画の自動ダウンロード**: `vco convert` を実行すると、iCloud のみの動画は Swift PhotoKit を使用して自動的にダウンロードされます。`--skip-icloud` でスキップ可能です。
+
+**並列転送**: ダウンロードとアップロードは並列で実行されます（デフォルト: 3 同時）。`--parallel N` で調整可能です。Ctrl+C でグレースフルにキャンセルできます。
 
 変換は AWS Step Functions を通じて非同期で処理されます。変換を送信した後、状態を確認してタスクを管理できます：
 

--- a/src/vco/cli/main.py
+++ b/src/vco/cli/main.py
@@ -213,6 +213,13 @@ scan.help = get_help("scan.description")
 @click.option("--dry-run", is_flag=True, help=get_help("convert.dry_run"))
 @click.option("--skip-icloud", is_flag=True, help=get_help("convert.skip_icloud"))
 @click.option("--download-timeout", type=int, help=get_help("convert.download_timeout"))
+@click.option(
+    "--parallel",
+    "-p",
+    type=int,
+    default=3,
+    help="Number of concurrent transfers (1-10, default: 3)",
+)
 @click.option("--yes", "-y", is_flag=True, help=get_help("convert.yes"))
 @click.pass_context
 def convert(
@@ -222,6 +229,7 @@ def convert(
     dry_run: bool,
     skip_icloud: bool,
     download_timeout: int | None,
+    parallel: int,
     yes: bool,
 ):
     """Convert candidate videos to H.265."""
@@ -297,8 +305,8 @@ def convert(
 
     # Download iCloud videos (skip_confirm=True since we already confirmed)
     if icloud_candidates and not skip_icloud:
-        downloaded_candidates = _download_icloud_videos(
-            icloud_candidates, timeout, skip_confirm=True
+        downloaded_candidates = _download_icloud_videos_parallel(
+            icloud_candidates, timeout, parallel, skip_confirm=True
         )
 
     # Combine local and downloaded candidates
@@ -342,7 +350,7 @@ def convert(
         sys.exit(1)
 
     # Execute async conversion (skip_confirm=True since we already confirmed)
-    _convert_async(ctx, final_candidates, quality, aws_config, skip_confirm=True)
+    _convert_async_parallel(ctx, final_candidates, quality, aws_config, parallel, skip_confirm=True)
 
 
 # Override convert help text dynamically based on locale
@@ -1314,6 +1322,286 @@ def _download_icloud_videos(candidates, timeout: int, skip_confirm: bool) -> lis
     console.print()
 
     return downloaded_candidates
+
+
+def _download_icloud_videos_parallel(
+    candidates, timeout: int, concurrency_limit: int, skip_confirm: bool
+) -> list:
+    """Download iCloud videos in parallel before conversion.
+
+    Args:
+        candidates: List of ConversionCandidate with iCloud videos
+        timeout: Download timeout in seconds
+        concurrency_limit: Maximum concurrent downloads (1-10)
+        skip_confirm: Skip confirmation prompt
+
+    Returns:
+        List of candidates that were successfully downloaded
+    """
+    from rich.progress import (
+        BarColumn,
+        Progress,
+        SpinnerColumn,
+        TextColumn,
+        TimeElapsedColumn,
+    )
+
+    from vco.photos.swift_bridge import SwiftBridge
+    from vco.services.icloud_download import ICloudDownloadService
+    from vco.services.parallel_transfer import ParallelTransferService
+
+    # Calculate total download size
+    total_size = sum(c.video.file_size for c in candidates)
+
+    # Initialize SwiftBridge
+    try:
+        swift_bridge = SwiftBridge()
+    except Exception as e:
+        console.print(f"[red]Error: Swift bridge unavailable: {e}[/red]")
+        return []
+
+    # Initialize download service (without progress callback - we'll handle it ourselves)
+    download_service = ICloudDownloadService(
+        swift_bridge=swift_bridge,
+        timeout=timeout,
+    )
+
+    # Check disk space
+    has_space, available = download_service.check_disk_space(total_size)
+    if not has_space:
+        console.print()
+        console.print("[red]Error: Insufficient disk space for iCloud downloads.[/red]")
+        console.print(f"  Required: {format_size(total_size * 1.1)}")
+        console.print(f"  Available: {format_size(available)}")
+        return []
+
+    # Show confirmation prompt
+    console.print()
+    console.print(f"[bold]iCloud videos to download: {len(candidates)}[/bold]")
+    console.print(f"  Estimated size: {format_size(total_size)}")
+    console.print(f"  Timeout: {timeout}s per video")
+    console.print(f"  Parallel downloads: {min(max(concurrency_limit, 1), 10)}")
+    console.print()
+
+    if not skip_confirm:
+        if not click.confirm("Download iCloud videos before conversion?"):
+            console.print("[yellow]Skipping iCloud videos.[/yellow]")
+            return []
+
+    # Download with progress display
+    console.print()
+    console.print("[bold]Downloading iCloud videos in parallel...[/bold]")
+
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.fields[filename]}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TextColumn("{task.fields[size]}"),
+        TimeElapsedColumn(),
+        console=console,
+    )
+
+    # Create download functions for each candidate
+    candidate_map: dict[str, Any] = {}  # item_id -> candidate
+
+    def create_download_func(candidate):
+        """Create a download function for a candidate."""
+        video = candidate.video
+
+        def download():
+            result = download_service.download_video(video)
+            if result.success and result.local_path:
+                # Update video path and is_local flag
+                video.path = result.local_path
+                video.is_local = True
+                return result.local_path
+            return None
+
+        return download
+
+    items = []
+    for candidate in candidates:
+        video = candidate.video
+        item_id = video.uuid
+        candidate_map[item_id] = candidate
+        items.append((item_id, video.filename, create_download_func(candidate)))
+
+    # Execute parallel downloads
+    parallel_service = ParallelTransferService(
+        concurrency_limit=concurrency_limit,
+    )
+
+    # Set up Ctrl+C handler
+    import signal
+
+    original_handler = signal.getsignal(signal.SIGINT)
+    cancelled = False
+
+    def handle_sigint(signum, frame):
+        nonlocal cancelled
+        cancelled = True
+        console.print("\n[yellow]Cancelling downloads...[/yellow]")
+        parallel_service.cancel()
+
+    signal.signal(signal.SIGINT, handle_sigint)
+
+    try:
+        with progress:
+            # Add overall progress task
+            overall_task = progress.add_task(
+                "download",
+                filename=f"Downloading 0/{len(candidates)} files",
+                size=format_size(total_size),
+                total=len(candidates),
+            )
+
+            # Custom callback to update progress
+            def update_progress(filename: str, percent: int, current: int, total: int) -> None:
+                progress.update(
+                    overall_task,
+                    completed=current,
+                    filename=f"Downloading {current}/{total} files",
+                )
+
+            parallel_service.progress_callback = update_progress
+            summary = parallel_service.download_parallel(items)
+
+            # Complete the progress bar
+            progress.update(overall_task, completed=len(candidates))
+    finally:
+        # Restore original signal handler
+        signal.signal(signal.SIGINT, original_handler)
+
+    if cancelled:
+        console.print("[yellow]Download cancelled by user.[/yellow]")
+        console.print()
+
+    # Collect successful downloads
+    downloaded_candidates: list[Any] = []
+    failed_downloads: list[tuple[str, str | None]] = []
+
+    for result in summary.results:
+        candidate = candidate_map.get(result.item_id)
+        if candidate:
+            if result.success:
+                console.print(
+                    f"  [green]✓[/green] {result.filename} ({result.transfer_time_seconds:.1f}s)"
+                )
+                downloaded_candidates.append(candidate)
+            else:
+                console.print(f"  [red]✗[/red] {result.filename}: {result.error_message}")
+                failed_downloads.append((result.filename, result.error_message))
+
+    # Show summary
+    console.print()
+    console.print("[bold]Download Summary[/bold]")
+    console.print(f"  Successful: [green]{summary.successful}[/green]")
+    console.print(f"  Failed: [red]{summary.failed}[/red]")
+    console.print(f"  Total time: {summary.total_time_seconds:.1f}s")
+
+    if failed_downloads:
+        console.print()
+        console.print("[red]Failed downloads:[/red]")
+        for filename, error in failed_downloads[:5]:
+            console.print(f"  - {filename}: {error}")
+        if len(failed_downloads) > 5:
+            console.print(f"  ... and {len(failed_downloads) - 5} more")
+
+    console.print()
+
+    return downloaded_candidates
+
+
+def _convert_async_parallel(
+    ctx, candidates, quality: str, aws_config, concurrency_limit: int, skip_confirm: bool = False
+):
+    """Handle async conversion mode with parallel uploads."""
+    from rich.progress import (
+        BarColumn,
+        DownloadColumn,
+        Progress,
+        SpinnerColumn,
+        TextColumn,
+        TransferSpeedColumn,
+    )
+
+    from vco.services.async_convert import AsyncConvertCommand
+
+    # Get API URL from config or use default
+    api_url = getattr(aws_config, "async_api_url", None)
+    if not api_url:
+        # Use default API URL based on region
+        api_url = f"https://dln48ri1di.execute-api.{aws_config.region}.amazonaws.com/dev"
+
+    console.print()
+    console.print("[bold]Async conversion mode[/bold]")
+    console.print(f"API URL: {api_url}")
+    console.print(f"Parallel uploads: {min(max(concurrency_limit, 1), 10)}")
+
+    try:
+        async_cmd = AsyncConvertCommand(
+            api_url=api_url,
+            s3_bucket=aws_config.s3_bucket,
+            region=aws_config.region,
+            profile_name=aws_config.profile or None,
+        )
+
+        console.print("[bold]Uploading files in parallel...[/bold]")
+
+        # Use Rich Progress for upload progress display
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.fields[filename]}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            console=console,
+        )
+
+        # Execute parallel upload using AsyncConvertCommand's parallel method
+        with progress:
+            overall_task = progress.add_task(
+                "upload",
+                filename=f"Uploading 0/{len(candidates)} files",
+                total=len(candidates),
+            )
+
+            def upload_progress_callback(
+                filename: str, percent: int, current: int, total: int
+            ) -> None:
+                progress.update(
+                    overall_task,
+                    completed=current,
+                    filename=f"Uploading {current}/{total} files",
+                )
+
+            result = async_cmd.execute_parallel(
+                candidates=candidates,
+                quality_preset=quality,
+                concurrency_limit=concurrency_limit,
+                progress_callback=upload_progress_callback,
+            )
+
+            # Complete the progress bar
+            progress.update(overall_task, completed=len(candidates))
+
+        if result.status == "ERROR":
+            console.print(f"[red]✗ Failed: {result.error_message}[/red]")
+            sys.exit(1)
+
+        console.print()
+        console.print("[green]✓ Task submitted successfully[/green]")
+        console.print(f"  Task ID: [cyan]{result.task_id}[/cyan]")
+        console.print(f"  Files: {result.file_count}")
+        console.print()
+        console.print("[dim]Use 'vco status' to check progress[/dim]")
+        console.print(f"[dim]Use 'vco status {result.task_id}' for details[/dim]")
+
+    except Exception as e:
+        console.print(f"[red]✗ Failed to submit task: {e}[/red]")
+        sys.exit(1)
 
 
 def _convert_async(ctx, candidates, quality: str, aws_config, skip_confirm: bool = False):

--- a/src/vco/cli/main.py
+++ b/src/vco/cli/main.py
@@ -1343,7 +1343,6 @@ def _download_icloud_videos_parallel(
         Progress,
         SpinnerColumn,
         TextColumn,
-        TimeElapsedColumn,
     )
 
     from vco.photos.swift_bridge import SwiftBridge
@@ -1390,27 +1389,56 @@ def _download_icloud_videos_parallel(
 
     # Download with progress display
     console.print()
-    console.print("[bold]Downloading iCloud videos in parallel...[/bold]")
+
+    from rich.progress import (
+        DownloadColumn,
+        TimeRemainingColumn,
+        TransferSpeedColumn,
+    )
 
     progress = Progress(
         SpinnerColumn(),
-        TextColumn("[bold blue]{task.fields[filename]}"),
+        TextColumn("[bold blue]{task.description}"),
         BarColumn(),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-        TextColumn("{task.fields[size]}"),
-        TimeElapsedColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
         console=console,
     )
 
     # Create download functions for each candidate
     candidate_map: dict[str, Any] = {}  # item_id -> candidate
+    download_tasks: dict[str, Any] = {}  # filename -> task_id
 
     def create_download_func(candidate):
-        """Create a download function for a candidate."""
+        """Create a download function for a candidate with progress tracking."""
+        from vco.services.icloud_download import DownloadProgress
+
         video = candidate.video
+        filename = video.filename
 
         def download():
+            # Add task when download starts
+            if filename not in download_tasks:
+                task_id = progress.add_task(f"Downloading {filename}", total=video.file_size)
+                download_tasks[filename] = task_id
+
+            # Create progress callback for this specific download
+            def progress_callback(dp: DownloadProgress) -> None:
+                task_id = download_tasks.get(filename)
+                if task_id is not None:
+                    progress.update(task_id, completed=dp.downloaded_bytes)
+
+            # Set progress callback for this download
+            download_service.progress_callback = progress_callback
+
             result = download_service.download_video(video)
+
+            # Hide progress bar on completion
+            task_id = download_tasks.get(filename)
+            if task_id is not None:
+                progress.update(task_id, visible=False)
+
             if result.success and result.local_path:
                 # Update video path and is_local flag
                 video.path = result.local_path
@@ -1448,27 +1476,7 @@ def _download_icloud_videos_parallel(
 
     try:
         with progress:
-            # Add overall progress task
-            overall_task = progress.add_task(
-                "download",
-                filename=f"Downloading 0/{len(candidates)} files",
-                size=format_size(total_size),
-                total=len(candidates),
-            )
-
-            # Custom callback to update progress
-            def update_progress(filename: str, percent: int, current: int, total: int) -> None:
-                progress.update(
-                    overall_task,
-                    completed=current,
-                    filename=f"Downloading {current}/{total} files",
-                )
-
-            parallel_service.progress_callback = update_progress
             summary = parallel_service.download_parallel(items)
-
-            # Complete the progress bar
-            progress.update(overall_task, completed=len(candidates))
     finally:
         # Restore original signal handler
         signal.signal(signal.SIGINT, original_handler)
@@ -1517,12 +1525,16 @@ def _convert_async_parallel(
     ctx, candidates, quality: str, aws_config, concurrency_limit: int, skip_confirm: bool = False
 ):
     """Handle async conversion mode with parallel uploads."""
+    import time
+
     from rich.progress import (
         BarColumn,
         DownloadColumn,
         Progress,
         SpinnerColumn,
+        TaskID,
         TextColumn,
+        TimeRemainingColumn,
         TransferSpeedColumn,
     )
 
@@ -1547,47 +1559,64 @@ def _convert_async_parallel(
             profile_name=aws_config.profile or None,
         )
 
-        console.print("[bold]Uploading files in parallel...[/bold]")
+        console.print("[bold]Uploading files to S3...[/bold]")
 
-        # Use Rich Progress for upload progress display
+        # Use Rich Progress for upload progress display (same style as iCloud download)
         progress = Progress(
             SpinnerColumn(),
-            TextColumn("[bold blue]{task.fields[filename]}"),
+            TextColumn("[bold blue]{task.description}"),
             BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
             DownloadColumn(),
             TransferSpeedColumn(),
+            TimeRemainingColumn(),
             console=console,
         )
 
+        # Track upload tasks and timing
+        upload_tasks: dict[str, TaskID] = {}  # filename -> task_id
+        upload_start_times: dict[str, float] = {}  # filename -> start_time
+        completed_uploads: list[tuple[str, float]] = []  # (filename, duration)
+
+        def file_progress_callback(filename: str, uploaded_bytes: int, total_bytes: int) -> None:
+            """Display upload progress for each file using rich Progress."""
+            if filename not in upload_tasks:
+                task_id = progress.add_task(f"Uploading {filename}", total=total_bytes)
+                upload_tasks[filename] = task_id
+                upload_start_times[filename] = time.time()
+            progress.update(upload_tasks[filename], completed=uploaded_bytes)
+
+            # Hide progress bar when upload is complete
+            if uploaded_bytes >= total_bytes:
+                progress.update(upload_tasks[filename], visible=False)
+                duration = time.time() - upload_start_times.get(filename, time.time())
+                completed_uploads.append((filename, duration))
+
         # Execute parallel upload using AsyncConvertCommand's parallel method
+        upload_start = time.time()
         with progress:
-            overall_task = progress.add_task(
-                "upload",
-                filename=f"Uploading 0/{len(candidates)} files",
-                total=len(candidates),
-            )
-
-            def upload_progress_callback(
-                filename: str, percent: int, current: int, total: int
-            ) -> None:
-                progress.update(
-                    overall_task,
-                    completed=current,
-                    filename=f"Uploading {current}/{total} files",
-                )
-
             result = async_cmd.execute_parallel(
                 candidates=candidates,
                 quality_preset=quality,
                 concurrency_limit=concurrency_limit,
-                progress_callback=upload_progress_callback,
+                file_progress_callback=file_progress_callback,
             )
+        upload_total_time = time.time() - upload_start
 
-            # Complete the progress bar
-            progress.update(overall_task, completed=len(candidates))
+        # Show completion status for each file
+        for filename, duration in completed_uploads:
+            console.print(f"  [green]✓[/green] {filename} ({duration:.1f}s)")
+
+        # Show upload summary
+        successful_count = len(completed_uploads)
+        failed_count = len(candidates) - successful_count
+        console.print()
+        console.print("[bold]Upload Summary[/bold]")
+        console.print(f"  Successful: [green]{successful_count}[/green]")
+        console.print(f"  Failed: [red]{failed_count}[/red]")
+        console.print(f"  Total time: {upload_total_time:.1f}s")
 
         if result.status == "ERROR":
+            console.print()
             console.print(f"[red]✗ Failed: {result.error_message}[/red]")
             sys.exit(1)
 

--- a/src/vco/cli/progress_display.py
+++ b/src/vco/cli/progress_display.py
@@ -1,0 +1,168 @@
+"""Progress display for parallel transfers.
+
+This module provides Rich-based progress display for concurrent file transfers,
+showing individual progress bars for each active transfer and overall progress.
+"""
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+
+@dataclass
+class TransferState:
+    """State of a single transfer."""
+
+    filename: str
+    task_id: TaskID | None = None
+    started_at: float = 0.0
+    completed_at: float = 0.0
+    is_complete: bool = False
+    is_success: bool = False
+
+
+@dataclass
+class ParallelProgressDisplay:
+    """Display progress for parallel file transfers.
+
+    Shows:
+    - Overall progress (e.g., "3/10 files completed")
+    - Individual progress bars for active transfers
+    - Estimated time remaining based on throughput
+    """
+
+    console: Console
+    total_files: int
+    operation: str = "Transferring"  # "Downloading" or "Uploading"
+    _progress: Progress | None = field(default=None, init=False)
+    _overall_task: TaskID | None = field(default=None, init=False)
+    _active_transfers: dict[str, TransferState] = field(default_factory=dict, init=False)
+    _completed_count: int = field(default=0, init=False)
+    _start_time: float = field(default=0.0, init=False)
+    _completed_times: list[float] = field(default_factory=list, init=False)
+
+    def __enter__(self) -> "ParallelProgressDisplay":
+        """Start the progress display."""
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=self.console,
+        )
+        self._progress.start()
+        self._start_time = time.time()
+
+        # Add overall progress task
+        self._overall_task = self._progress.add_task(
+            f"{self.operation} 0/{self.total_files} files",
+            total=self.total_files,
+        )
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Stop the progress display."""
+        if self._progress:
+            # Complete the overall task
+            if self._overall_task is not None:
+                self._progress.update(
+                    self._overall_task,
+                    completed=self.total_files,
+                    description=f"{self.operation} {self.total_files}/{self.total_files} files",
+                )
+            self._progress.stop()
+
+    def start_transfer(self, item_id: str, filename: str) -> None:
+        """Mark a transfer as started.
+
+        Args:
+            item_id: Unique identifier for the transfer
+            filename: Name of the file being transferred
+        """
+        if self._progress is None:
+            return
+
+        state = TransferState(
+            filename=filename,
+            started_at=time.time(),
+        )
+        self._active_transfers[item_id] = state
+
+    def complete_transfer(self, item_id: str, success: bool) -> None:
+        """Mark a transfer as completed.
+
+        Args:
+            item_id: Unique identifier for the transfer
+            success: Whether the transfer was successful
+        """
+        if self._progress is None or self._overall_task is None:
+            return
+
+        state = self._active_transfers.get(item_id)
+        if state:
+            state.completed_at = time.time()
+            state.is_complete = True
+            state.is_success = success
+
+            # Track completion time for ETA calculation
+            transfer_time = state.completed_at - state.started_at
+            self._completed_times.append(transfer_time)
+
+        self._completed_count += 1
+
+        # Update overall progress
+        self._progress.update(
+            self._overall_task,
+            completed=self._completed_count,
+            description=f"{self.operation} {self._completed_count}/{self.total_files} files",
+        )
+
+    def get_progress_callback(self) -> Callable[[str, int, int, int], None]:
+        """Get a callback function for progress updates.
+
+        Returns:
+            Callback function (filename, percent, current, total)
+        """
+
+        def callback(filename: str, percent: int, current: int, total: int) -> None:
+            if self._progress is None or self._overall_task is None:
+                return
+
+            self._completed_count = current
+            self._progress.update(
+                self._overall_task,
+                completed=current,
+                description=f"{self.operation} {current}/{total} files",
+            )
+
+        return callback
+
+    def get_estimated_remaining_seconds(self) -> float | None:
+        """Calculate estimated remaining time based on throughput.
+
+        Returns:
+            Estimated seconds remaining, or None if not enough data
+        """
+        if not self._completed_times or self._completed_count == 0:
+            return None
+
+        # Calculate average time per file
+        avg_time = sum(self._completed_times) / len(self._completed_times)
+
+        # Estimate remaining time
+        remaining_files = self.total_files - self._completed_count
+        return avg_time * remaining_files

--- a/src/vco/services/async_convert.py
+++ b/src/vco/services/async_convert.py
@@ -466,3 +466,213 @@ class AsyncConvertCommand:
                     total_bytes=total_bytes,
                 )
             )
+
+    def execute_parallel(
+        self,
+        candidates: list[ConversionCandidate],
+        quality_preset: str = "balanced",
+        user_id: str | None = None,
+        concurrency_limit: int = 3,
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> AsyncTaskResult:
+        """Submit async conversion task with parallel uploads.
+
+        1. Generate task ID
+        2. Upload source files to S3 in parallel
+        3. Submit task to API Gateway
+        4. Return task ID for tracking
+
+        Args:
+            candidates: List of conversion candidates
+            quality_preset: Quality preset for conversion
+            user_id: User identifier (defaults to machine ID)
+            concurrency_limit: Maximum concurrent uploads (1-10)
+            progress_callback: Callback for progress updates (filename, percent, current, total)
+
+        Returns:
+            AsyncTaskResult with task ID and status
+        """
+        from vco.services.parallel_transfer import ParallelTransferService
+
+        if not candidates:
+            return AsyncTaskResult(
+                task_id="",
+                status="ERROR",
+                file_count=0,
+                message="No candidates provided",
+                error_message="No candidates provided",
+            )
+
+        # Generate task ID
+        task_id = str(uuid.uuid4())
+
+        # Use machine ID as user_id if not provided
+        if user_id is None:
+            user_id = self._get_machine_id()
+
+        logger.info(
+            f"Submitting async task {task_id} with {len(candidates)} files (parallel={concurrency_limit})"
+        )
+
+        # Filter local candidates only
+        local_candidates = []
+        skipped_candidates = []
+
+        for candidate in candidates:
+            video = candidate.video
+            if self._check_file_available(video.path):
+                local_candidates.append(candidate)
+            else:
+                skipped_candidates.append(candidate)
+                logger.warning(f"Skipping iCloud-only file: {video.filename}")
+
+        if not local_candidates:
+            return AsyncTaskResult(
+                task_id=task_id,
+                status="ERROR",
+                file_count=0,
+                message="No local files available for upload",
+                error_message="All files are in iCloud only. Download them in Photos app first.",
+            )
+
+        # Prepare upload items
+        files_data: list[dict] = []
+        upload_items: list[tuple[str, str, Callable[[], bool]]] = []
+        candidate_file_map: dict[str, tuple[ConversionCandidate, str, str, str]] = {}
+
+        for candidate in local_candidates:
+            video = candidate.video
+            file_id = str(uuid.uuid4())
+
+            source_s3_key = f"async/{task_id}/input/{file_id}/{video.filename}"
+            metadata_s3_key = f"async/{task_id}/input/{file_id}/metadata.json"
+
+            # Store mapping for later
+            candidate_file_map[file_id] = (candidate, file_id, source_s3_key, metadata_s3_key)
+
+            def create_upload_func(
+                cand: ConversionCandidate,
+                fid: str,
+                src_key: str,
+                meta_key: str,
+            ) -> Callable[[], bool]:
+                """Create upload function for a candidate."""
+
+                def upload() -> bool:
+                    vid = cand.video
+                    try:
+                        # Upload source file (without progress callback for parallel)
+                        self.s3_client.upload_file(
+                            str(vid.path),
+                            self.s3_bucket,
+                            src_key,
+                        )
+
+                        # Extract and upload metadata
+                        metadata = self._extract_metadata(vid)
+                        self._upload_metadata(metadata, meta_key)
+
+                        logger.info(f"Uploaded {vid.filename} to s3://{self.s3_bucket}/{src_key}")
+                        return True
+                    except Exception as e:
+                        logger.error(f"Failed to upload {vid.filename}: {e}")
+                        return False
+
+                return upload
+
+            upload_items.append(
+                (
+                    file_id,
+                    video.filename,
+                    create_upload_func(candidate, file_id, source_s3_key, metadata_s3_key),
+                )
+            )
+
+        # Execute parallel uploads
+        parallel_service = ParallelTransferService(
+            concurrency_limit=concurrency_limit,
+            progress_callback=progress_callback,
+        )
+
+        try:
+            summary = parallel_service.upload_parallel(upload_items)
+
+            # Collect successful uploads
+            for result in summary.results:
+                if result.success:
+                    mapping = candidate_file_map.get(result.item_id)
+                    if mapping:
+                        candidate, file_id, source_s3_key, metadata_s3_key = mapping
+                        video = candidate.video
+                        files_data.append(
+                            {
+                                "file_id": file_id,
+                                "original_uuid": video.uuid,
+                                "filename": video.filename,
+                                "source_s3_key": source_s3_key,
+                                "metadata_s3_key": metadata_s3_key,
+                                "source_size_bytes": video.file_size,
+                            }
+                        )
+
+            if not files_data:
+                logger.error(f"All uploads failed for task {task_id}")
+                self._cleanup_task_files(task_id)
+                return AsyncTaskResult(
+                    task_id=task_id,
+                    status="ERROR",
+                    file_count=0,
+                    message="All uploads failed",
+                    error_message="Failed to upload any files to S3",
+                )
+
+            logger.info(
+                f"Parallel upload complete: {summary.successful}/{summary.total} successful "
+                f"in {summary.total_time_seconds:.1f}s"
+            )
+
+        except Exception as e:
+            logger.exception(f"Failed to upload files for task {task_id}")
+            self._cleanup_task_files(task_id)
+            return AsyncTaskResult(
+                task_id=task_id,
+                status="ERROR",
+                file_count=0,
+                message="Failed to upload files",
+                error_message=str(e),
+            )
+
+        # Submit task to API Gateway
+        try:
+            self._submit_task(
+                task_id=task_id,
+                user_id=user_id,
+                quality_preset=quality_preset,
+                files=files_data,
+            )
+
+            failed_count = len(local_candidates) - len(files_data)
+            message = f"Task submitted successfully. {len(files_data)} files uploaded"
+            if failed_count > 0:
+                message += f", {failed_count} uploads failed"
+            if skipped_candidates:
+                message += f", {len(skipped_candidates)} files skipped (iCloud only)"
+
+            return AsyncTaskResult(
+                task_id=task_id,
+                status="PENDING",
+                file_count=len(files_data),
+                message=message,
+                api_url=self.api_url,
+            )
+
+        except Exception as e:
+            logger.exception(f"Failed to submit task {task_id}")
+            self._cleanup_task_files(task_id)
+            return AsyncTaskResult(
+                task_id=task_id,
+                status="ERROR",
+                file_count=0,
+                message="Failed to submit task",
+                error_message=str(e),
+            )

--- a/src/vco/services/async_convert.py
+++ b/src/vco/services/async_convert.py
@@ -474,6 +474,7 @@ class AsyncConvertCommand:
         user_id: str | None = None,
         concurrency_limit: int = 3,
         progress_callback: Callable[[str, int, int, int], None] | None = None,
+        file_progress_callback: Callable[[str, int, int], None] | None = None,
     ) -> AsyncTaskResult:
         """Submit async conversion task with parallel uploads.
 
@@ -487,7 +488,8 @@ class AsyncConvertCommand:
             quality_preset: Quality preset for conversion
             user_id: User identifier (defaults to machine ID)
             concurrency_limit: Maximum concurrent uploads (1-10)
-            progress_callback: Callback for progress updates (filename, percent, current, total)
+            progress_callback: Callback for overall progress (filename, percent, current, total)
+            file_progress_callback: Callback for per-file byte progress (filename, uploaded_bytes, total_bytes)
 
         Returns:
             AsyncTaskResult with task ID and status
@@ -561,11 +563,21 @@ class AsyncConvertCommand:
                 def upload() -> bool:
                     vid = cand.video
                     try:
-                        # Upload source file (without progress callback for parallel)
+                        # Track cumulative bytes for progress callback
+                        bytes_uploaded = 0
+
+                        def s3_progress_callback(bytes_amount: int) -> None:
+                            nonlocal bytes_uploaded
+                            bytes_uploaded += bytes_amount
+                            if file_progress_callback:
+                                file_progress_callback(vid.filename, bytes_uploaded, vid.file_size)
+
+                        # Upload source file with progress callback
                         self.s3_client.upload_file(
                             str(vid.path),
                             self.s3_bucket,
                             src_key,
+                            Callback=s3_progress_callback if file_progress_callback else None,
                         )
 
                         # Extract and upload metadata

--- a/src/vco/services/parallel_transfer.py
+++ b/src/vco/services/parallel_transfer.py
@@ -1,0 +1,359 @@
+"""Parallel transfer service for concurrent iCloud downloads and S3 uploads.
+
+This module provides parallel file transfer capabilities using ThreadPoolExecutor
+to improve overall transfer performance when processing multiple files.
+"""
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+
+@dataclass
+class ConcurrencyConfig:
+    """Configuration for parallel transfer concurrency limits.
+
+    Attributes:
+        download_limit: Maximum concurrent downloads (1-10, default: 3)
+        upload_limit: Maximum concurrent uploads (1-10, default: 3)
+    """
+
+    download_limit: int = 3
+    upload_limit: int = 3
+
+    def __post_init__(self) -> None:
+        """Validate and clamp concurrency limits to valid range (1-10)."""
+        self.download_limit = min(max(self.download_limit, 1), 10)
+        self.upload_limit = min(max(self.upload_limit, 1), 10)
+
+
+@dataclass
+class TransferResult:
+    """Result of a single file transfer operation.
+
+    Attributes:
+        item_id: Unique identifier for the transferred item
+        filename: Name of the transferred file
+        success: Whether the transfer completed successfully
+        local_path: Local file path (for downloads) or None
+        error_message: Error message if transfer failed
+        transfer_time_seconds: Time taken for the transfer in seconds
+    """
+
+    item_id: str
+    filename: str
+    success: bool
+    local_path: Path | None = None
+    error_message: str | None = None
+    transfer_time_seconds: float = 0.0
+
+
+@dataclass
+class TransferSummary:
+    """Summary of a parallel transfer operation.
+
+    Attributes:
+        total: Total number of transfers attempted
+        successful: Number of successful transfers
+        failed: Number of failed transfers
+        results: List of individual transfer results
+        total_time_seconds: Total time for all transfers in seconds
+    """
+
+    total: int
+    successful: int
+    failed: int
+    results: list[TransferResult]
+    total_time_seconds: float
+
+    def __post_init__(self) -> None:
+        """Validate summary integrity."""
+        # Ensure counts match results
+        if self.results:
+            actual_successful = sum(1 for r in self.results if r.success)
+            actual_failed = sum(1 for r in self.results if not r.success)
+            if self.successful != actual_successful:
+                self.successful = actual_successful
+            if self.failed != actual_failed:
+                self.failed = actual_failed
+            if self.total != len(self.results):
+                self.total = len(self.results)
+
+
+@dataclass
+class TransferProgress:
+    """Progress information for a single transfer.
+
+    Attributes:
+        filename: Name of the file being transferred
+        progress_percent: Transfer progress (0-100)
+        transferred_bytes: Number of bytes transferred
+        total_bytes: Total file size in bytes
+        status: Current transfer status
+    """
+
+    filename: str
+    progress_percent: int
+    transferred_bytes: int
+    total_bytes: int
+    status: str  # "downloading", "uploading", "completed", "failed"
+
+
+# =============================================================================
+# Parallel Transfer Service
+# =============================================================================
+
+
+class ParallelTransferService:
+    """Service for managing parallel file transfers.
+
+    Uses ThreadPoolExecutor to execute multiple downloads or uploads
+    concurrently while respecting the configured concurrency limits.
+    """
+
+    def __init__(
+        self,
+        concurrency_limit: int = 3,
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> None:
+        """Initialize the parallel transfer service.
+
+        Args:
+            concurrency_limit: Maximum number of concurrent transfers (1-10, default: 3)
+            progress_callback: Optional callback for progress updates
+                              (filename, percent, current_index, total_count)
+        """
+        self.concurrency_limit = min(max(concurrency_limit, 1), 10)
+        self.progress_callback = progress_callback
+        self._active_count = 0
+        self._active_count_lock = threading.Lock()
+        self._max_active_count = 0
+
+    def _track_active(self, increment: bool) -> None:
+        """Track the number of active transfers for testing.
+
+        Args:
+            increment: True to increment, False to decrement
+        """
+        with self._active_count_lock:
+            if increment:
+                self._active_count += 1
+                self._max_active_count = max(self._max_active_count, self._active_count)
+            else:
+                self._active_count -= 1
+
+    def get_max_active_count(self) -> int:
+        """Get the maximum number of concurrent transfers observed.
+
+        Returns:
+            Maximum number of transfers that were active simultaneously
+        """
+        return self._max_active_count
+
+    def reset_tracking(self) -> None:
+        """Reset the active count tracking for testing."""
+        with self._active_count_lock:
+            self._active_count = 0
+            self._max_active_count = 0
+
+    def download_parallel(
+        self,
+        items: list[tuple[str, str, Callable[[], Path | None]]],
+    ) -> TransferSummary:
+        """Download multiple files in parallel.
+
+        Args:
+            items: List of (item_id, filename, download_func) tuples
+                   download_func should return the local Path on success or None on failure
+
+        Returns:
+            TransferSummary with results for all downloads
+        """
+        start_time = time.time()
+        results: list[TransferResult] = []
+
+        if not items:
+            return TransferSummary(
+                total=0,
+                successful=0,
+                failed=0,
+                results=[],
+                total_time_seconds=0.0,
+            )
+
+        self.reset_tracking()
+
+        def execute_download(
+            item_id: str, filename: str, download_func: Callable[[], Path | None]
+        ) -> TransferResult:
+            """Execute a single download with tracking."""
+            transfer_start = time.time()
+            self._track_active(True)
+            try:
+                local_path = download_func()
+                transfer_time = time.time() - transfer_start
+                if local_path:
+                    return TransferResult(
+                        item_id=item_id,
+                        filename=filename,
+                        success=True,
+                        local_path=local_path,
+                        transfer_time_seconds=transfer_time,
+                    )
+                else:
+                    return TransferResult(
+                        item_id=item_id,
+                        filename=filename,
+                        success=False,
+                        error_message="Download returned None",
+                        transfer_time_seconds=transfer_time,
+                    )
+            except Exception as e:
+                transfer_time = time.time() - transfer_start
+                logger.error(f"Download failed for {filename}: {e}")
+                return TransferResult(
+                    item_id=item_id,
+                    filename=filename,
+                    success=False,
+                    error_message=str(e),
+                    transfer_time_seconds=transfer_time,
+                )
+            finally:
+                self._track_active(False)
+
+        with ThreadPoolExecutor(max_workers=self.concurrency_limit) as executor:
+            futures = {
+                executor.submit(execute_download, item_id, filename, download_func): (
+                    item_id,
+                    filename,
+                )
+                for item_id, filename, download_func in items
+            }
+
+            completed_count = 0
+            for future in as_completed(futures):
+                result = future.result()
+                results.append(result)
+                completed_count += 1
+
+                if self.progress_callback:
+                    self.progress_callback(
+                        result.filename,
+                        100 if result.success else 0,
+                        completed_count,
+                        len(items),
+                    )
+
+        total_time = time.time() - start_time
+        successful = sum(1 for r in results if r.success)
+        failed = sum(1 for r in results if not r.success)
+
+        return TransferSummary(
+            total=len(results),
+            successful=successful,
+            failed=failed,
+            results=results,
+            total_time_seconds=total_time,
+        )
+
+    def upload_parallel(
+        self,
+        items: list[tuple[str, str, Callable[[], bool]]],
+    ) -> TransferSummary:
+        """Upload multiple files in parallel.
+
+        Args:
+            items: List of (item_id, filename, upload_func) tuples
+                   upload_func should return True on success, False on failure
+
+        Returns:
+            TransferSummary with results for all uploads
+        """
+        start_time = time.time()
+        results: list[TransferResult] = []
+
+        if not items:
+            return TransferSummary(
+                total=0,
+                successful=0,
+                failed=0,
+                results=[],
+                total_time_seconds=0.0,
+            )
+
+        self.reset_tracking()
+
+        def execute_upload(
+            item_id: str, filename: str, upload_func: Callable[[], bool]
+        ) -> TransferResult:
+            """Execute a single upload with tracking."""
+            transfer_start = time.time()
+            self._track_active(True)
+            try:
+                success = upload_func()
+                transfer_time = time.time() - transfer_start
+                return TransferResult(
+                    item_id=item_id,
+                    filename=filename,
+                    success=success,
+                    error_message=None if success else "Upload returned False",
+                    transfer_time_seconds=transfer_time,
+                )
+            except Exception as e:
+                transfer_time = time.time() - transfer_start
+                logger.error(f"Upload failed for {filename}: {e}")
+                return TransferResult(
+                    item_id=item_id,
+                    filename=filename,
+                    success=False,
+                    error_message=str(e),
+                    transfer_time_seconds=transfer_time,
+                )
+            finally:
+                self._track_active(False)
+
+        with ThreadPoolExecutor(max_workers=self.concurrency_limit) as executor:
+            futures = {
+                executor.submit(execute_upload, item_id, filename, upload_func): (
+                    item_id,
+                    filename,
+                )
+                for item_id, filename, upload_func in items
+            }
+
+            completed_count = 0
+            for future in as_completed(futures):
+                result = future.result()
+                results.append(result)
+                completed_count += 1
+
+                if self.progress_callback:
+                    self.progress_callback(
+                        result.filename,
+                        100 if result.success else 0,
+                        completed_count,
+                        len(items),
+                    )
+
+        total_time = time.time() - start_time
+        successful = sum(1 for r in results if r.success)
+        failed = sum(1 for r in results if not r.success)
+
+        return TransferSummary(
+            total=len(results),
+            successful=successful,
+            failed=failed,
+            results=results,
+            total_time_seconds=total_time,
+        )

--- a/src/vco/services/parallel_transfer.py
+++ b/src/vco/services/parallel_transfer.py
@@ -8,7 +8,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -80,15 +80,14 @@ class TransferSummary:
     def __post_init__(self) -> None:
         """Validate summary integrity."""
         # Ensure counts match results
-        if self.results:
-            actual_successful = sum(1 for r in self.results if r.success)
-            actual_failed = sum(1 for r in self.results if not r.success)
-            if self.successful != actual_successful:
-                self.successful = actual_successful
-            if self.failed != actual_failed:
-                self.failed = actual_failed
-            if self.total != len(self.results):
-                self.total = len(self.results)
+        actual_successful = sum(1 for r in self.results if r.success)
+        actual_failed = sum(1 for r in self.results if not r.success)
+        if self.successful != actual_successful:
+            self.successful = actual_successful
+        if self.failed != actual_failed:
+            self.failed = actual_failed
+        if self.total != len(self.results):
+            self.total = len(self.results)
 
 
 @dataclass
@@ -120,6 +119,7 @@ class ParallelTransferService:
 
     Uses ThreadPoolExecutor to execute multiple downloads or uploads
     concurrently while respecting the configured concurrency limits.
+    Supports graceful cancellation via Ctrl+C.
     """
 
     def __init__(
@@ -139,6 +139,42 @@ class ParallelTransferService:
         self._active_count = 0
         self._active_count_lock = threading.Lock()
         self._max_active_count = 0
+        self._cancelled = False
+        self._cancel_lock = threading.Lock()
+        self._executor: ThreadPoolExecutor | None = None
+        self._futures: list[Future] = []
+
+    def cancel(self) -> None:
+        """Cancel all pending transfers.
+
+        Running transfers will complete, but no new transfers will start.
+        """
+        with self._cancel_lock:
+            self._cancelled = True
+            logger.info("Transfer cancellation requested")
+
+        # Cancel pending futures
+        for future in self._futures:
+            future.cancel()
+
+        # Shutdown executor without waiting
+        if self._executor:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def is_cancelled(self) -> bool:
+        """Check if cancellation has been requested.
+
+        Returns:
+            True if cancel() has been called
+        """
+        with self._cancel_lock:
+            return self._cancelled
+
+    def _reset_cancel_state(self) -> None:
+        """Reset cancellation state for new transfer operation."""
+        with self._cancel_lock:
+            self._cancelled = False
+        self._futures = []
 
     def _track_active(self, increment: bool) -> None:
         """Track the number of active transfers for testing.
@@ -233,6 +269,9 @@ class ParallelTransferService:
                 self._track_active(False)
 
         with ThreadPoolExecutor(max_workers=self.concurrency_limit) as executor:
+            self._executor = executor
+            self._reset_cancel_state()
+
             futures = {
                 executor.submit(execute_download, item_id, filename, download_func): (
                     item_id,
@@ -240,11 +279,40 @@ class ParallelTransferService:
                 )
                 for item_id, filename, download_func in items
             }
+            self._futures = list(futures.keys())
 
             completed_count = 0
+            cancelled_count = 0
             for future in as_completed(futures):
-                result = future.result()
-                results.append(result)
+                if self.is_cancelled():
+                    # Mark remaining as cancelled
+                    cancelled_count += 1
+                    item_id, filename = futures[future]
+                    results.append(
+                        TransferResult(
+                            item_id=item_id,
+                            filename=filename,
+                            success=False,
+                            error_message="Cancelled by user",
+                            transfer_time_seconds=0.0,
+                        )
+                    )
+                    continue
+
+                try:
+                    result = future.result()
+                    results.append(result)
+                except Exception as e:
+                    item_id, filename = futures[future]
+                    results.append(
+                        TransferResult(
+                            item_id=item_id,
+                            filename=filename,
+                            success=False,
+                            error_message=str(e),
+                            transfer_time_seconds=0.0,
+                        )
+                    )
                 completed_count += 1
 
                 if self.progress_callback:
@@ -254,6 +322,8 @@ class ParallelTransferService:
                         completed_count,
                         len(items),
                     )
+
+            self._executor = None
 
         total_time = time.time() - start_time
         successful = sum(1 for r in results if r.success)
@@ -324,6 +394,9 @@ class ParallelTransferService:
                 self._track_active(False)
 
         with ThreadPoolExecutor(max_workers=self.concurrency_limit) as executor:
+            self._executor = executor
+            self._reset_cancel_state()
+
             futures = {
                 executor.submit(execute_upload, item_id, filename, upload_func): (
                     item_id,
@@ -331,11 +404,38 @@ class ParallelTransferService:
                 )
                 for item_id, filename, upload_func in items
             }
+            self._futures = list(futures.keys())
 
             completed_count = 0
             for future in as_completed(futures):
-                result = future.result()
-                results.append(result)
+                if self.is_cancelled():
+                    # Mark remaining as cancelled
+                    item_id, filename = futures[future]
+                    results.append(
+                        TransferResult(
+                            item_id=item_id,
+                            filename=filename,
+                            success=False,
+                            error_message="Cancelled by user",
+                            transfer_time_seconds=0.0,
+                        )
+                    )
+                    continue
+
+                try:
+                    result = future.result()
+                    results.append(result)
+                except Exception as e:
+                    item_id, filename = futures[future]
+                    results.append(
+                        TransferResult(
+                            item_id=item_id,
+                            filename=filename,
+                            success=False,
+                            error_message=str(e),
+                            transfer_time_seconds=0.0,
+                        )
+                    )
                 completed_count += 1
 
                 if self.progress_callback:
@@ -345,6 +445,8 @@ class ParallelTransferService:
                         completed_count,
                         len(items),
                     )
+
+            self._executor = None
 
         total_time = time.time() - start_time
         successful = sum(1 for r in results if r.success)

--- a/tests/unit/test_icloud_download_parallel_progress.py
+++ b/tests/unit/test_icloud_download_parallel_progress.py
@@ -1,0 +1,244 @@
+"""Unit tests for iCloud parallel download progress display.
+
+Tests cover:
+- Dynamic progress callback assignment
+- Progress callback updates during download
+- Multiple concurrent downloads with separate progress tracking
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vco.models.types import VideoInfo
+from vco.services.icloud_download import (
+    DownloadProgress,
+    ICloudDownloadService,
+)
+
+
+@pytest.fixture
+def mock_swift_bridge():
+    """Create a mock SwiftBridge."""
+    return MagicMock()
+
+
+@pytest.fixture
+def sample_video():
+    """Create a sample VideoInfo for testing."""
+    return VideoInfo(
+        uuid="test-uuid-123",
+        filename="test_video.mov",
+        path=Path("/tmp/test_video.mov"),
+        codec="h264",
+        resolution=(1920, 1080),
+        bitrate=10000000,
+        duration=60.0,
+        frame_rate=30.0,
+        file_size=100_000_000,
+        capture_date=None,
+        creation_date=None,
+        albums=[],
+        is_in_icloud=True,
+        is_local=False,
+        location=None,
+    )
+
+
+class TestDynamicProgressCallback:
+    """Tests for dynamic progress callback assignment."""
+
+    def test_progress_callback_can_be_set_after_init(self, mock_swift_bridge, sample_video):
+        """Test that progress_callback can be set after initialization."""
+        expected_path = Path("/tmp/downloaded_video.mov")
+        mock_swift_bridge.download_from_icloud.return_value = expected_path
+
+        # Initialize without progress callback
+        service = ICloudDownloadService(
+            swift_bridge=mock_swift_bridge,
+            timeout=300,
+        )
+
+        progress_updates = []
+
+        def progress_callback(progress: DownloadProgress):
+            progress_updates.append(progress)
+
+        # Set progress callback dynamically (like CLI does)
+        service.progress_callback = progress_callback
+
+        result = service.download_video(sample_video)
+
+        assert result.success is True
+        # Progress callback should have been called
+        assert len(progress_updates) >= 2  # At least start (0%) and end (100%)
+        assert progress_updates[0].progress_percent == 0.0
+        assert progress_updates[-1].progress_percent == 100.0
+
+    def test_progress_callback_can_be_changed_between_downloads(
+        self, mock_swift_bridge, sample_video
+    ):
+        """Test that progress_callback can be changed between downloads."""
+        expected_path = Path("/tmp/downloaded_video.mov")
+        mock_swift_bridge.download_from_icloud.return_value = expected_path
+
+        service = ICloudDownloadService(
+            swift_bridge=mock_swift_bridge,
+            timeout=300,
+        )
+
+        # First download with callback 1
+        updates_1 = []
+        service.progress_callback = lambda p: updates_1.append(p)
+        service.download_video(sample_video)
+
+        # Second download with callback 2
+        updates_2 = []
+        service.progress_callback = lambda p: updates_2.append(p)
+        service.download_video(sample_video)
+
+        # Both callbacks should have received updates
+        assert len(updates_1) >= 2
+        assert len(updates_2) >= 2
+
+        # Updates should be separate
+        assert updates_1 is not updates_2
+
+    def test_progress_callback_receives_correct_video_info(
+        self, mock_swift_bridge, sample_video
+    ):
+        """Test that progress callback receives correct video information."""
+        expected_path = Path("/tmp/downloaded_video.mov")
+        mock_swift_bridge.download_from_icloud.return_value = expected_path
+
+        service = ICloudDownloadService(
+            swift_bridge=mock_swift_bridge,
+            timeout=300,
+        )
+
+        progress_updates = []
+        service.progress_callback = lambda p: progress_updates.append(p)
+
+        service.download_video(sample_video)
+
+        # All updates should have correct video info
+        for update in progress_updates:
+            assert update.uuid == sample_video.uuid
+            assert update.filename == sample_video.filename
+            assert update.total_bytes == sample_video.file_size
+
+
+class TestProgressCallbackIntegration:
+    """Tests for progress callback integration with parallel downloads."""
+
+    def test_multiple_videos_with_separate_callbacks(self, mock_swift_bridge):
+        """Test that multiple videos can have separate progress tracking."""
+        video1 = VideoInfo(
+            uuid="video-1",
+            filename="video1.mov",
+            path=Path("/tmp/video1.mov"),
+            codec="h264",
+            resolution=(1920, 1080),
+            bitrate=10000000,
+            duration=60.0,
+            frame_rate=30.0,
+            file_size=100_000_000,
+            capture_date=None,
+            creation_date=None,
+            albums=[],
+            is_in_icloud=True,
+            is_local=False,
+            location=None,
+        )
+
+        video2 = VideoInfo(
+            uuid="video-2",
+            filename="video2.mov",
+            path=Path("/tmp/video2.mov"),
+            codec="h264",
+            resolution=(1920, 1080),
+            bitrate=10000000,
+            duration=60.0,
+            frame_rate=30.0,
+            file_size=200_000_000,
+            capture_date=None,
+            creation_date=None,
+            albums=[],
+            is_in_icloud=True,
+            is_local=False,
+            location=None,
+        )
+
+        mock_swift_bridge.download_from_icloud.return_value = Path("/tmp/downloaded.mov")
+
+        service = ICloudDownloadService(
+            swift_bridge=mock_swift_bridge,
+            timeout=300,
+        )
+
+        # Track updates per video
+        updates_by_video: dict[str, list[DownloadProgress]] = {}
+
+        def create_callback(video_uuid: str):
+            def callback(progress: DownloadProgress):
+                if video_uuid not in updates_by_video:
+                    updates_by_video[video_uuid] = []
+                updates_by_video[video_uuid].append(progress)
+
+            return callback
+
+        # Download video1 with its callback
+        service.progress_callback = create_callback("video-1")
+        service.download_video(video1)
+
+        # Download video2 with its callback
+        service.progress_callback = create_callback("video-2")
+        service.download_video(video2)
+
+        # Both videos should have progress updates
+        assert "video-1" in updates_by_video
+        assert "video-2" in updates_by_video
+
+        # Each video's updates should have correct file size
+        for update in updates_by_video["video-1"]:
+            assert update.total_bytes == video1.file_size
+
+        for update in updates_by_video["video-2"]:
+            assert update.total_bytes == video2.file_size
+
+    def test_swift_bridge_progress_callback_updates_service_callback(
+        self, mock_swift_bridge, sample_video
+    ):
+        """Test that SwiftBridge progress callback triggers service callback."""
+        expected_path = Path("/tmp/downloaded_video.mov")
+
+        # Capture the progress callback passed to SwiftBridge
+        captured_swift_callback = None
+
+        def capture_callback(**kwargs):
+            nonlocal captured_swift_callback
+            captured_swift_callback = kwargs.get("progress_callback")
+            return expected_path
+
+        mock_swift_bridge.download_from_icloud.side_effect = capture_callback
+
+        service = ICloudDownloadService(
+            swift_bridge=mock_swift_bridge,
+            timeout=300,
+        )
+
+        progress_updates = []
+        service.progress_callback = lambda p: progress_updates.append(p)
+
+        service.download_video(sample_video)
+
+        # SwiftBridge should have received a progress callback
+        assert captured_swift_callback is not None
+
+        # Simulate SwiftBridge calling the callback with progress
+        captured_swift_callback(50)  # 50%
+
+        # Service callback should have been called
+        # (initial 0%, then 50% from swift callback, then 100% at end)
+        assert any(u.progress_percent == 50.0 for u in progress_updates)

--- a/tests/unit/test_icloud_download_parallel_progress.py
+++ b/tests/unit/test_icloud_download_parallel_progress.py
@@ -7,7 +7,7 @@ Tests cover:
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/unit/test_icloud_download_parallel_progress.py
+++ b/tests/unit/test_icloud_download_parallel_progress.py
@@ -105,9 +105,7 @@ class TestDynamicProgressCallback:
         # Updates should be separate
         assert updates_1 is not updates_2
 
-    def test_progress_callback_receives_correct_video_info(
-        self, mock_swift_bridge, sample_video
-    ):
+    def test_progress_callback_receives_correct_video_info(self, mock_swift_bridge, sample_video):
         """Test that progress callback receives correct video information."""
         expected_path = Path("/tmp/downloaded_video.mov")
         mock_swift_bridge.download_from_icloud.return_value = expected_path

--- a/tests/unit/test_parallel_transfer_properties.py
+++ b/tests/unit/test_parallel_transfer_properties.py
@@ -1,0 +1,552 @@
+"""Property-based tests for ParallelTransferService.
+
+Tests correctness properties using Hypothesis.
+
+Feature: parallel-transfer
+Requirements: 1.1, 1.3, 2.1, 2.3, 3.3, 3.4, 5.1, 5.2, 5.4
+"""
+
+import time
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from vco.services.parallel_transfer import (
+    ConcurrencyConfig,
+    ParallelTransferService,
+    TransferResult,
+    TransferSummary,
+)
+
+# =============================================================================
+# Strategies for generating test data
+# =============================================================================
+
+# Concurrency limit values (including edge cases)
+concurrency_limit = st.integers(min_value=-100, max_value=200)
+
+# Valid concurrency limit values (1-10)
+valid_concurrency_limit = st.integers(min_value=1, max_value=10)
+
+# Number of items to transfer
+item_count = st.integers(min_value=0, max_value=20)
+
+# Success/failure probability
+success_probability = st.floats(min_value=0.0, max_value=1.0)
+
+
+# =============================================================================
+# Property 6: Concurrency Limit Validation
+# Feature: parallel-transfer, Property 6: Concurrency limit validation
+# Validates: Requirements 3.3, 3.4
+# =============================================================================
+
+
+class TestConcurrencyLimitValidationProperty:
+    """Property 6: Concurrency limit validation.
+
+    *For any* concurrency limit value:
+    - If value < 1, the system shall use 1
+    - If value > 10, the system shall use 10
+    - Otherwise, the system shall use the specified value
+    """
+
+    @given(limit=concurrency_limit)
+    @settings(max_examples=100)
+    def test_concurrency_config_clamps_download_limit(self, limit: int):
+        """Property 6: ConcurrencyConfig clamps download_limit to 1-10.
+
+        Feature: parallel-transfer, Property 6: Concurrency limit validation
+        Validates: Requirements 3.3, 3.4
+        """
+        config = ConcurrencyConfig(download_limit=limit)
+
+        # Value should be clamped to 1-10
+        assert 1 <= config.download_limit <= 10
+
+        # Verify clamping logic
+        if limit < 1:
+            assert config.download_limit == 1
+        elif limit > 10:
+            assert config.download_limit == 10
+        else:
+            assert config.download_limit == limit
+
+    @given(limit=concurrency_limit)
+    @settings(max_examples=100)
+    def test_concurrency_config_clamps_upload_limit(self, limit: int):
+        """Property 6: ConcurrencyConfig clamps upload_limit to 1-10.
+
+        Feature: parallel-transfer, Property 6: Concurrency limit validation
+        Validates: Requirements 3.3, 3.4
+        """
+        config = ConcurrencyConfig(upload_limit=limit)
+
+        # Value should be clamped to 1-10
+        assert 1 <= config.upload_limit <= 10
+
+        # Verify clamping logic
+        if limit < 1:
+            assert config.upload_limit == 1
+        elif limit > 10:
+            assert config.upload_limit == 10
+        else:
+            assert config.upload_limit == limit
+
+    @given(limit=concurrency_limit)
+    @settings(max_examples=100)
+    def test_parallel_transfer_service_clamps_limit(self, limit: int):
+        """Property 6: ParallelTransferService clamps concurrency_limit to 1-10.
+
+        Feature: parallel-transfer, Property 6: Concurrency limit validation
+        Validates: Requirements 3.3, 3.4
+        """
+        service = ParallelTransferService(concurrency_limit=limit)
+
+        # Value should be clamped to 1-10
+        assert 1 <= service.concurrency_limit <= 10
+
+        # Verify clamping logic
+        if limit < 1:
+            assert service.concurrency_limit == 1
+        elif limit > 10:
+            assert service.concurrency_limit == 10
+        else:
+            assert service.concurrency_limit == limit
+
+    @given(
+        download_limit=concurrency_limit,
+        upload_limit=concurrency_limit,
+    )
+    @settings(max_examples=100)
+    def test_both_limits_clamped_independently(self, download_limit: int, upload_limit: int):
+        """Property 6: Both limits are clamped independently.
+
+        Feature: parallel-transfer, Property 6: Concurrency limit validation
+        Validates: Requirements 3.3, 3.4
+        """
+        config = ConcurrencyConfig(download_limit=download_limit, upload_limit=upload_limit)
+
+        # Both should be in valid range
+        assert 1 <= config.download_limit <= 10
+        assert 1 <= config.upload_limit <= 10
+
+
+# =============================================================================
+# Property 1: Concurrency Limit Respected for Downloads
+# Feature: parallel-transfer, Property 1: Concurrency limit is respected for downloads
+# Validates: Requirements 1.1
+# =============================================================================
+
+
+class TestDownloadConcurrencyProperty:
+    """Property 1: Concurrency limit is respected for downloads.
+
+    *For any* list of videos and any concurrency limit N (1 ≤ N ≤ 10),
+    at no point during parallel download execution shall more than N
+    downloads be active simultaneously.
+    """
+
+    @given(
+        limit=valid_concurrency_limit,
+        num_items=st.integers(min_value=1, max_value=15),
+    )
+    @settings(max_examples=100)
+    def test_download_concurrency_never_exceeds_limit(self, limit: int, num_items: int):
+        """Property 1: Download concurrency never exceeds limit.
+
+        Feature: parallel-transfer, Property 1: Concurrency limit is respected for downloads
+        Validates: Requirements 1.1
+        """
+        service = ParallelTransferService(concurrency_limit=limit)
+
+        # Create download functions that track concurrent execution
+        def create_download_func(item_id: str):
+            def download():
+                time.sleep(0.01)  # Small delay to allow overlap
+                return Path(f"/tmp/{item_id}")
+
+            return download
+
+        items = [
+            (f"item-{i}", f"file-{i}.mp4", create_download_func(f"item-{i}"))
+            for i in range(num_items)
+        ]
+
+        result = service.download_parallel(items)
+
+        # Verify concurrency was never exceeded
+        max_active = service.get_max_active_count()
+        assert max_active <= limit, f"Max active downloads ({max_active}) exceeded limit ({limit})"
+
+        # Verify all items were processed
+        assert result.total == num_items
+
+    @given(limit=valid_concurrency_limit)
+    @settings(max_examples=50)
+    def test_empty_download_list_returns_empty_summary(self, limit: int):
+        """Property 1: Empty download list returns empty summary.
+
+        Feature: parallel-transfer, Property 1: Concurrency limit is respected for downloads
+        Validates: Requirements 1.1
+        """
+        service = ParallelTransferService(concurrency_limit=limit)
+        result = service.download_parallel([])
+
+        assert result.total == 0
+        assert result.successful == 0
+        assert result.failed == 0
+        assert len(result.results) == 0
+
+
+# =============================================================================
+# Property 2: Concurrency Limit Respected for Uploads
+# Feature: parallel-transfer, Property 2: Concurrency limit is respected for uploads
+# Validates: Requirements 2.1
+# =============================================================================
+
+
+class TestUploadConcurrencyProperty:
+    """Property 2: Concurrency limit is respected for uploads.
+
+    *For any* list of files and any concurrency limit N (1 ≤ N ≤ 10),
+    at no point during parallel upload execution shall more than N
+    uploads be active simultaneously.
+    """
+
+    @given(
+        limit=valid_concurrency_limit,
+        num_items=st.integers(min_value=1, max_value=15),
+    )
+    @settings(max_examples=100)
+    def test_upload_concurrency_never_exceeds_limit(self, limit: int, num_items: int):
+        """Property 2: Upload concurrency never exceeds limit.
+
+        Feature: parallel-transfer, Property 2: Concurrency limit is respected for uploads
+        Validates: Requirements 2.1
+        """
+        service = ParallelTransferService(concurrency_limit=limit)
+
+        # Create upload functions that track concurrent execution
+        def create_upload_func():
+            def upload():
+                time.sleep(0.01)  # Small delay to allow overlap
+                return True
+
+            return upload
+
+        items = [(f"item-{i}", f"file-{i}.mp4", create_upload_func()) for i in range(num_items)]
+
+        result = service.upload_parallel(items)
+
+        # Verify concurrency was never exceeded
+        max_active = service.get_max_active_count()
+        assert max_active <= limit, f"Max active uploads ({max_active}) exceeded limit ({limit})"
+
+        # Verify all items were processed
+        assert result.total == num_items
+
+    @given(limit=valid_concurrency_limit)
+    @settings(max_examples=50)
+    def test_empty_upload_list_returns_empty_summary(self, limit: int):
+        """Property 2: Empty upload list returns empty summary.
+
+        Feature: parallel-transfer, Property 2: Concurrency limit is respected for uploads
+        Validates: Requirements 2.1
+        """
+        service = ParallelTransferService(concurrency_limit=limit)
+        result = service.upload_parallel([])
+
+        assert result.total == 0
+        assert result.successful == 0
+        assert result.failed == 0
+        assert len(result.results) == 0
+
+
+# =============================================================================
+# Property 3: Download Failures Do Not Affect Other Downloads
+# Feature: parallel-transfer, Property 3: Download failures do not affect other downloads
+# Validates: Requirements 1.3, 5.1
+# =============================================================================
+
+
+class TestDownloadFailureIsolationProperty:
+    """Property 3: Download failures do not affect other downloads.
+
+    *For any* list of videos where some downloads fail, all non-failing
+    downloads shall complete successfully and be included in the result.
+    """
+
+    @given(
+        num_items=st.integers(min_value=2, max_value=10),
+        fail_indices=st.lists(st.integers(min_value=0, max_value=9), min_size=1, max_size=5),
+    )
+    @settings(max_examples=100)
+    def test_successful_downloads_complete_despite_failures(
+        self, num_items: int, fail_indices: list[int]
+    ):
+        """Property 3: Successful downloads complete despite failures.
+
+        Feature: parallel-transfer, Property 3: Download failures do not affect other downloads
+        Validates: Requirements 1.3, 5.1
+        """
+        # Normalize fail_indices to be within range
+        fail_set = {i % num_items for i in fail_indices}
+
+        service = ParallelTransferService(concurrency_limit=3)
+
+        def create_download_func(item_id: str, should_fail: bool):
+            def download():
+                if should_fail:
+                    raise Exception(f"Simulated failure for {item_id}")
+                return Path(f"/tmp/{item_id}")
+
+            return download
+
+        items = [
+            (f"item-{i}", f"file-{i}.mp4", create_download_func(f"item-{i}", i in fail_set))
+            for i in range(num_items)
+        ]
+
+        result = service.download_parallel(items)
+
+        # All items should be processed
+        assert result.total == num_items
+
+        # Count expected successes and failures
+        expected_failures = len(fail_set)
+        expected_successes = num_items - expected_failures
+
+        assert result.successful == expected_successes
+        assert result.failed == expected_failures
+
+        # Verify each result
+        for r in result.results:
+            item_idx = int(r.item_id.split("-")[1])
+            if item_idx in fail_set:
+                assert r.success is False
+                assert r.error_message is not None
+            else:
+                assert r.success is True
+                assert r.local_path is not None
+
+
+# =============================================================================
+# Property 4: Upload Failures Do Not Affect Other Uploads
+# Feature: parallel-transfer, Property 4: Upload failures do not affect other uploads
+# Validates: Requirements 2.3, 5.2
+# =============================================================================
+
+
+class TestUploadFailureIsolationProperty:
+    """Property 4: Upload failures do not affect other uploads.
+
+    *For any* list of files where some uploads fail, all non-failing
+    uploads shall complete successfully and be included in the result.
+    """
+
+    @given(
+        num_items=st.integers(min_value=2, max_value=10),
+        fail_indices=st.lists(st.integers(min_value=0, max_value=9), min_size=1, max_size=5),
+    )
+    @settings(max_examples=100)
+    def test_successful_uploads_complete_despite_failures(
+        self, num_items: int, fail_indices: list[int]
+    ):
+        """Property 4: Successful uploads complete despite failures.
+
+        Feature: parallel-transfer, Property 4: Upload failures do not affect other uploads
+        Validates: Requirements 2.3, 5.2
+        """
+        # Normalize fail_indices to be within range
+        fail_set = {i % num_items for i in fail_indices}
+
+        service = ParallelTransferService(concurrency_limit=3)
+
+        def create_upload_func(item_id: str, should_fail: bool):
+            def upload():
+                if should_fail:
+                    raise Exception(f"Simulated failure for {item_id}")
+                return True
+
+            return upload
+
+        items = [
+            (f"item-{i}", f"file-{i}.mp4", create_upload_func(f"item-{i}", i in fail_set))
+            for i in range(num_items)
+        ]
+
+        result = service.upload_parallel(items)
+
+        # All items should be processed
+        assert result.total == num_items
+
+        # Count expected successes and failures
+        expected_failures = len(fail_set)
+        expected_successes = num_items - expected_failures
+
+        assert result.successful == expected_successes
+        assert result.failed == expected_failures
+
+        # Verify each result
+        for r in result.results:
+            item_idx = int(r.item_id.split("-")[1])
+            if item_idx in fail_set:
+                assert r.success is False
+                assert r.error_message is not None
+            else:
+                assert r.success is True
+
+
+# =============================================================================
+# Property 5: Transfer Summary Integrity
+# Feature: parallel-transfer, Property 5: Transfer summary integrity
+# Validates: Requirements 1.5, 2.5, 5.4
+# =============================================================================
+
+
+class TestTransferSummaryIntegrityProperty:
+    """Property 5: Transfer summary integrity.
+
+    *For any* parallel transfer operation, the returned summary shall satisfy:
+    - total == successful + failed
+    - successful equals the count of results with success=True
+    - failed equals the count of results with success=False
+    - Each failed result contains a non-empty error_message
+    """
+
+    @given(
+        num_items=st.integers(min_value=1, max_value=15),
+        success_pattern=st.lists(st.booleans(), min_size=1, max_size=15),
+    )
+    @settings(max_examples=100)
+    def test_download_summary_integrity(self, num_items: int, success_pattern: list[bool]):
+        """Property 5: Download summary has correct counts.
+
+        Feature: parallel-transfer, Property 5: Transfer summary integrity
+        Validates: Requirements 1.5, 2.5, 5.4
+        """
+        # Adjust pattern to match num_items
+        pattern = (success_pattern * ((num_items // len(success_pattern)) + 1))[:num_items]
+
+        service = ParallelTransferService(concurrency_limit=3)
+
+        def create_download_func(should_succeed: bool):
+            def download():
+                if should_succeed:
+                    return Path("/tmp/test")
+                else:
+                    raise Exception("Simulated failure")
+
+            return download
+
+        items = [
+            (f"item-{i}", f"file-{i}.mp4", create_download_func(pattern[i]))
+            for i in range(num_items)
+        ]
+
+        result = service.download_parallel(items)
+
+        # Verify total == successful + failed
+        assert result.total == result.successful + result.failed
+
+        # Verify counts match results
+        actual_successful = sum(1 for r in result.results if r.success)
+        actual_failed = sum(1 for r in result.results if not r.success)
+
+        assert result.successful == actual_successful
+        assert result.failed == actual_failed
+
+        # Verify failed results have error messages
+        for r in result.results:
+            if not r.success:
+                assert r.error_message is not None
+                assert len(r.error_message) > 0
+
+    @given(
+        num_items=st.integers(min_value=1, max_value=15),
+        success_pattern=st.lists(st.booleans(), min_size=1, max_size=15),
+    )
+    @settings(max_examples=100)
+    def test_upload_summary_integrity(self, num_items: int, success_pattern: list[bool]):
+        """Property 5: Upload summary has correct counts.
+
+        Feature: parallel-transfer, Property 5: Transfer summary integrity
+        Validates: Requirements 1.5, 2.5, 5.4
+        """
+        # Adjust pattern to match num_items
+        pattern = (success_pattern * ((num_items // len(success_pattern)) + 1))[:num_items]
+
+        service = ParallelTransferService(concurrency_limit=3)
+
+        def create_upload_func(should_succeed: bool):
+            def upload():
+                if should_succeed:
+                    return True
+                else:
+                    raise Exception("Simulated failure")
+
+            return upload
+
+        items = [
+            (f"item-{i}", f"file-{i}.mp4", create_upload_func(pattern[i])) for i in range(num_items)
+        ]
+
+        result = service.upload_parallel(items)
+
+        # Verify total == successful + failed
+        assert result.total == result.successful + result.failed
+
+        # Verify counts match results
+        actual_successful = sum(1 for r in result.results if r.success)
+        actual_failed = sum(1 for r in result.results if not r.success)
+
+        assert result.successful == actual_successful
+        assert result.failed == actual_failed
+
+        # Verify failed results have error messages
+        for r in result.results:
+            if not r.success:
+                assert r.error_message is not None
+                assert len(r.error_message) > 0
+
+    @given(
+        total=st.integers(min_value=0, max_value=100),
+        successful=st.integers(min_value=0, max_value=100),
+        failed=st.integers(min_value=0, max_value=100),
+    )
+    @settings(max_examples=100)
+    def test_transfer_summary_auto_corrects_counts(self, total: int, successful: int, failed: int):
+        """Property 5: TransferSummary auto-corrects mismatched counts.
+
+        Feature: parallel-transfer, Property 5: Transfer summary integrity
+        Validates: Requirements 1.5, 2.5, 5.4
+        """
+        # Create results that may not match the provided counts
+        results = []
+        for i in range(total):
+            results.append(
+                TransferResult(
+                    item_id=f"item-{i}",
+                    filename=f"file-{i}.mp4",
+                    success=(i % 2 == 0),  # Alternating success/failure
+                    error_message=None if (i % 2 == 0) else "Error",
+                )
+            )
+
+        summary = TransferSummary(
+            total=total,
+            successful=successful,  # May not match actual
+            failed=failed,  # May not match actual
+            results=results,
+            total_time_seconds=1.0,
+        )
+
+        # After __post_init__, counts should match results
+        actual_successful = sum(1 for r in results if r.success)
+        actual_failed = sum(1 for r in results if not r.success)
+
+        assert summary.successful == actual_successful
+        assert summary.failed == actual_failed
+        assert summary.total == len(results)


### PR DESCRIPTION
## 変更内容

`vco convert` コマンドに並列転送機能を追加しました。

- `--parallel` オプションで同時転送数を設定（デフォルト: 3、範囲: 1-10）
- iCloud ダウンロードと S3 アップロードを並列実行
- Rich Progress による全体進捗表示
- Ctrl+C によるグレースフルキャンセル
- 一部失敗時も残りの転送を継続

## 変更理由

複数ファイルの変換時、順次処理では時間がかかるため、並列処理により全体の処理時間を短縮します。

## 実装詳細

- `ParallelTransferService`: ThreadPoolExecutor を使用した並列転送サービス
- `ParallelProgressDisplay`: Rich Progress を使用した進捗表示クラス
- `_download_icloud_videos_parallel()`: 並列 iCloud ダウンロード
- `_convert_async_parallel()`: 並列 S3 アップロード
- `AsyncConvertCommand.execute_parallel()`: 並列アップロード実行メソッド

## テスト

- [x] Property tests (13 tests) - 並列実行の正確性検証
- [x] Unit tests (969 tests) - 全テスト通過
- [x] Lint/Format/Type check - 全検証通過

## チェックリスト

- [x] コードレビュー準備完了
- [x] ドキュメント更新済み（README.md, README_JP.md, CHANGELOG.md）
- [x] 破壊的変更なし

Closes #24