### PR TITLE
fix(ci): add Swift build step to release workflow test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         run: |
           pip install -e ".[dev]"
 
+      - name: Build Swift binary
+        run: |
+          cd swift && swift build -c release
+          mkdir -p ../bin
+          cp .build/release/vco-photos ../bin/
+
       - name: Run unit tests
         run: |
           pytest tests/unit/ -v --cov=src/vco --cov-report=term


### PR DESCRIPTION
## 変更内容

`release.yml` の `test` ジョブに Swift ビルドステップを追加。

## 変更理由

`test_unified_import.py` のテストが `vco-photos` バイナリを必要とするため、テスト実行前に Swift バイナリをビルドする必要がある。

## 修正内容

```yaml
- name: Build Swift binary
  run: |
    cd swift && swift build -c release
    mkdir -p ../bin
    cp .build/release/vco-photos ../bin/
```