### PR TITLE
refactor: extract NotificationManager protocol for testability

### DIFF
--- a/VCOMenuBar/Sources/VCOMenuBar/Controllers/PipelineController.swift
+++ b/VCOMenuBar/Sources/VCOMenuBar/Controllers/PipelineController.swift
@@ -12,7 +12,7 @@ class PipelineController: ObservableObject {
     let cliRunner: CLIRunner
     let stateStore: StateStore
     let configReader: ConfigReader
-    let notificationManager: NotificationManager
+    let notificationManager: NotificationManaging
 
     private var pollingTimer: Timer?
     private var lastPolledStatus: String?
@@ -22,7 +22,7 @@ class PipelineController: ObservableObject {
         cliRunner: CLIRunner = CLIRunner(),
         stateStore: StateStore = StateStore(),
         configReader: ConfigReader = ConfigReader(),
-        notificationManager: NotificationManager = NotificationManager()
+        notificationManager: NotificationManaging = NotificationManager()
     ) {
         self.cliRunner = cliRunner
         self.stateStore = stateStore

--- a/VCOMenuBar/Sources/VCOMenuBar/Services/NotificationManager.swift
+++ b/VCOMenuBar/Sources/VCOMenuBar/Services/NotificationManager.swift
@@ -1,7 +1,16 @@
 import Foundation
 import UserNotifications
 
-class NotificationManager {
+protocol NotificationManaging {
+    func requestPermission()
+    func sendPipelineComplete(successful: Int, failed: Int)
+    func sendAuthExpired()
+    func sendDiskSpaceInsufficient()
+    func sendAllFilesFailed()
+    func sendDeleteOriginalFailed(filename: String)
+}
+
+class NotificationManager: NotificationManaging {
     private var center: UNUserNotificationCenter?
 
     init() {

--- a/VCOMenuBar/Tests/VCOMenuBarTests/VCOMenuBarTests.swift
+++ b/VCOMenuBar/Tests/VCOMenuBarTests/VCOMenuBarTests.swift
@@ -193,15 +193,31 @@ final class CLIRunnerTests: XCTestCase {
 
 @MainActor
 final class PipelineControllerTests: XCTestCase {
+    class MockNotificationManager: NotificationManaging {
+        var requestPermissionCalled = false
+        var pipelineCompleteArgs: (successful: Int, failed: Int)?
+        var authExpiredCalled = false
+        var diskSpaceCalled = false
+        var allFilesFailedCalled = false
+        var deleteOriginalFailedFilename: String?
+
+        func requestPermission() { requestPermissionCalled = true }
+        func sendPipelineComplete(successful: Int, failed: Int) { pipelineCompleteArgs = (successful, failed) }
+        func sendAuthExpired() { authExpiredCalled = true }
+        func sendDiskSpaceInsufficient() { diskSpaceCalled = true }
+        func sendAllFilesFailed() { allFilesFailedCalled = true }
+        func sendDeleteOriginalFailed(filename: String) { deleteOriginalFailedFilename = filename }
+    }
+
     func testInitialState() {
-        let controller = PipelineController()
+        let controller = PipelineController(notificationManager: MockNotificationManager())
         XCTAssertEqual(controller.stage, .idle)
         XCTAssertTrue(controller.files.isEmpty)
         XCTAssertFalse(controller.isCancelRequested)
     }
 
     func testRequestStop() {
-        let controller = PipelineController()
+        let controller = PipelineController(notificationManager: MockNotificationManager())
         controller.stage = .polling
         controller.requestStop()
         XCTAssertTrue(controller.isCancelRequested)
@@ -209,7 +225,7 @@ final class PipelineControllerTests: XCTestCase {
     }
 
     func testRequestStopWhenIdle() {
-        let controller = PipelineController()
+        let controller = PipelineController(notificationManager: MockNotificationManager())
         controller.requestStop()
         XCTAssertFalse(controller.isCancelRequested)
         XCTAssertEqual(controller.stage, .idle)


### PR DESCRIPTION
Closes #31

## Changes

- Extract `NotificationManaging` protocol with all public methods
- `PipelineController` depends on protocol instead of concrete `NotificationManager`
- Add `MockNotificationManager` in tests
- All 20 swift tests now pass (previously PipelineControllerTests crashed)

## Before / After

| | Before | After |
|---|---|---|
| swift test | 14 passed, 6 crashed | 20 passed |
| PipelineController testable | ❌ | ✅ |