### PR TITLE
fix(test): add convert.json to i18n EXPECTED_KEYS

### DIFF
--- a/tests/properties/test_i18n.py
+++ b/tests/properties/test_i18n.py
@@ -184,6 +184,7 @@ class TestAllKeysHaveTranslations:
         "convert.skip_icloud",
         "convert.download_timeout",
         "convert.yes",
+        "convert.json",
         "import.description",
         "import.list",
         "import.all",


### PR DESCRIPTION
## Problem

CI failing because `convert.json` key was added to `HELP_MESSAGES` (for the `--json` flag on convert command) but not to the test's `EXPECTED_KEYS` list.

## Fix

Add `convert.json` to `EXPECTED_KEYS` in `tests/properties/test_i18n.py`.